### PR TITLE
Using platform Separator to Locate conf.json config file

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -265,7 +265,7 @@ func (d *Driver) Open(name string) (driver.Conn, error) {
 
 func init() {
 	fname := os.Getenv("GOPATH")
-	fname = fname + "\\src\\github.com\\IBM\\nzgo\\config\\conf.json"
+	fname = fname + filepath.FromSlash("/src/github.com/IBM/nzgo/config/conf.json")
 	file, _ := os.Open(fname)
 	defer file.Close()
 


### PR DESCRIPTION

Attached is the sample log file tested in Linux env
[nzgolang_nz10243.log.txt](https://github.com/IBM/nzgo/files/3834300/nzgolang_nz10243.log.txt)
