### PR TITLE
Provide support for JSON and JSONB datatypes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ documentation at <https://godoc.org/github.com/IBM/nzgo>.
 * Full external table support (load and unload)
 * Configurable logging feature
 * Prepared statement support
-* Support JSON datatype
+* Support JSON and JSONB datatypes
 
 ## Thank you (alphabetical)
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ documentation at <https://godoc.org/github.com/IBM/nzgo>.
 * Full external table support (load and unload)
 * Configurable logging feature
 * Prepared statement support
+* Support JSON and JSONB datatypes
 
 ## Thank you (alphabetical)
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ documentation at <https://godoc.org/github.com/IBM/nzgo>.
 * Full external table support (load and unload)
 * Configurable logging feature
 * Prepared statement support
-* Support JSON and JSONB datatypes
+* Support JSON datatype
 
 ## Thank you (alphabetical)
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ documentation at <https://godoc.org/github.com/IBM/nzgo>.
 * Full external table support (load and unload)
 * Configurable logging feature
 * Prepared statement support
-* Support JSON and JSONB datatypes
+* Support JSON, JSONB and JSONPATH datatypes
 
 ## Thank you (alphabetical)
 

--- a/conn.go
+++ b/conn.go
@@ -162,11 +162,10 @@ const (
 	NzDEPR_Blob // OBSOLETE 3.0: BLAST Era Large 'binary' Object
 	NzTypeNChar
 	NzTypeNVarChar
-	NzDEPR_NText // OBSOLETE 3.0: BLAST Era Large 'nchar text' Object
-	_            // skip 28
-	_            // skip 29
-	NzTypeJson   // 30
-	NzTypeJsonb
+	NzDEPR_NText    // OBSOLETE 3.0: BLAST Era Large 'nchar text' Object
+	_               // skip 28
+	_               // skip 29
+	NzTypeJson      // 30
 	NzTypeLastEntry // KEEP THIS ENTRY LAST - used internally to size an array
 )
 
@@ -188,7 +187,6 @@ var dataType = map[int]string{
 	NzTypeNChar:        "NzTypeNChar",
 	NzTypeNVarChar:     "NzTypeNVarChar",
 	NzTypeJson:         "NzTypeJson",
-	NzTypeJsonb:        "NzTypeJsonb",
 }
 
 const (
@@ -2665,8 +2663,6 @@ func (res *rows) Res_read_dbos_tuple(dest []driver.Value) {
 		case NzTypeNVarChar:
 			fallthrough
 		case NzTypeJson:
-			fallthrough
-		case NzTypeJsonb:
 			memsize *= 4
 			memsize = memsize + 1 // for NULL-termination
 			break
@@ -2743,8 +2739,6 @@ func (res *rows) Res_read_dbos_tuple(dest []driver.Value) {
 		case NzTypeVarBinary:
 			fallthrough
 		case NzTypeJson:
-			fallthrough
-		case NzTypeJsonb:
 			cursize := int(binary.LittleEndian.Uint16(fieldDataP)) - 2 //to ignore 2 bytes
 			fieldDataP.next(2)                                         //ignoring 2 bytes
 			dest[field_lf] = ""

--- a/conn.go
+++ b/conn.go
@@ -162,10 +162,11 @@ const (
 	NzDEPR_Blob // OBSOLETE 3.0: BLAST Era Large 'binary' Object
 	NzTypeNChar
 	NzTypeNVarChar
-	NzDEPR_NText    // OBSOLETE 3.0: BLAST Era Large 'nchar text' Object
-	_               // skip 28
-	_               // skip 29
-	NzTypeJson      // 30
+	NzDEPR_NText // OBSOLETE 3.0: BLAST Era Large 'nchar text' Object
+	_            // skip 28
+	_            // skip 29
+	NzTypeJson   // 30
+	NzTypeJsonb
 	NzTypeLastEntry // KEEP THIS ENTRY LAST - used internally to size an array
 )
 
@@ -187,6 +188,7 @@ var dataType = map[int]string{
 	NzTypeNChar:        "NzTypeNChar",
 	NzTypeNVarChar:     "NzTypeNVarChar",
 	NzTypeJson:         "NzTypeJson",
+	NzTypeJsonb:        "NzTypeJsonb",
 }
 
 const (
@@ -2663,6 +2665,8 @@ func (res *rows) Res_read_dbos_tuple(dest []driver.Value) {
 		case NzTypeNVarChar:
 			fallthrough
 		case NzTypeJson:
+			fallthrough
+		case NzTypeJsonb:
 			memsize *= 4
 			memsize = memsize + 1 // for NULL-termination
 			break
@@ -2739,6 +2743,8 @@ func (res *rows) Res_read_dbos_tuple(dest []driver.Value) {
 		case NzTypeVarBinary:
 			fallthrough
 		case NzTypeJson:
+			fallthrough
+		case NzTypeJsonb:
 			cursize := int(binary.LittleEndian.Uint16(fieldDataP)) - 2 //to ignore 2 bytes
 			fieldDataP.next(2)                                         //ignoring 2 bytes
 			dest[field_lf] = ""

--- a/conn.go
+++ b/conn.go
@@ -136,36 +136,38 @@ const (
 )
 
 const (
-	NzTypeRecAddr      = 1 // !NOTE-bmz need to add this to all switch stmts
-	NzTypeDouble       = 2
-	NzTypeInt          = 3
-	NzTypeFloat        = 4
-	NzTypeMoney        = 5
-	NzTypeDate         = 6
-	NzTypeNumeric      = 7
-	NzTypeTime         = 8
-	NzTypeTimestamp    = 9
-	NzTypeInterval     = 10
-	NzTypeTimeTz       = 11
-	NzTypeBool         = 12
-	NzTypeInt1         = 13
-	NzTypeBinary       = 14
-	NzTypeChar         = 15
-	NzTypeVarChar      = 16
-	NzDEPR_Text        = 17 // OBSOLETE 3.0: BLAST Era Large 'text' Object, (Postgres 'text' datatype overload, too)
-	NzTypeUnknown      = 18 // corresponds to PG UNKNOWNOID data type - an untyped string literal
-	NzTypeInt2         = 19
-	NzTypeInt8         = 20
-	NzTypeVarFixedChar = 21
-	NzTypeGeometry     = 22
-	NzTypeVarBinary    = 23
-	NzDEPR_Blob        = 24 // OBSOLETE 3.0: BLAST Era Large 'binary' Object
-	NzTypeNChar        = 25
-	NzTypeNVarChar     = 26
-	NzDEPR_NText       = 27 // OBSOLETE 3.0: BLAST Era Large 'nchar text' Object
-	NzTypeJson         = 30
-	NzTypeJsonb        = 31
-	NzTypeLastEntry    // KEEP THIS ENTRY LAST - used internally to size an array
+	NzTypeRecAddr = 1 + iota // !NOTE-bmz need to add this to all switch stmts
+	NzTypeDouble
+	NzTypeInt
+	NzTypeFloat
+	NzTypeMoney
+	NzTypeDate
+	NzTypeNumeric
+	NzTypeTime
+	NzTypeTimestamp
+	NzTypeInterval
+	NzTypeTimeTz
+	NzTypeBool
+	NzTypeInt1
+	NzTypeBinary
+	NzTypeChar
+	NzTypeVarChar
+	NzDEPR_Text   // OBSOLETE 3.0: BLAST Era Large 'text' Object, (Postgres 'text' datatype overload, too)
+	NzTypeUnknown // corresponds to PG UNKNOWNOID data type - an untyped string literal
+	NzTypeInt2
+	NzTypeInt8
+	NzTypeVarFixedChar
+	NzTypeGeometry
+	NzTypeVarBinary
+	NzDEPR_Blob // OBSOLETE 3.0: BLAST Era Large 'binary' Object
+	NzTypeNChar
+	NzTypeNVarChar
+	NzDEPR_NText // OBSOLETE 3.0: BLAST Era Large 'nchar text' Object
+	_            // skip 28
+	_            // skip 29
+	NzTypeJson   // 30
+	NzTypeJsonb
+	NzTypeLastEntry // KEEP THIS ENTRY LAST - used internally to size an array
 )
 
 const (
@@ -384,11 +386,11 @@ type conn struct {
 	inCopy bool
 
 	//netezza specific
-	hsVersion     int
-	protocol1     int
-	protocol2     int
-	commandNumber int
-	status        int
+	hsVersion               int
+	protocol1               int
+	protocol2               int
+	commandNumber           int
+	status                  int
 	guardium_clientHostName string
 	guardium_clientOSUser   string
 	guardium_applName       string

--- a/conn.go
+++ b/conn.go
@@ -167,6 +167,7 @@ const (
 	_            // skip 29
 	NzTypeJson   // 30
 	NzTypeJsonb
+	NzTypeJsonpath
 	NzTypeLastEntry // KEEP THIS ENTRY LAST - used internally to size an array
 )
 
@@ -189,6 +190,7 @@ var dataType = map[int]string{
 	NzTypeNVarChar:     "NzTypeNVarChar",
 	NzTypeJson:         "NzTypeJson",
 	NzTypeJsonb:        "NzTypeJsonb",
+	NzTypeJsonpath:     "NzTypeJsonpath",
 }
 
 const (
@@ -2667,6 +2669,8 @@ func (res *rows) Res_read_dbos_tuple(dest []driver.Value) {
 		case NzTypeJson:
 			fallthrough
 		case NzTypeJsonb:
+			fallthrough
+		case NzTypeJsonpath:
 			memsize *= 4
 			memsize = memsize + 1 // for NULL-termination
 			break
@@ -2745,6 +2749,8 @@ func (res *rows) Res_read_dbos_tuple(dest []driver.Value) {
 		case NzTypeJson:
 			fallthrough
 		case NzTypeJsonb:
+			fallthrough
+		case NzTypeJsonpath:
 			cursize := int(binary.LittleEndian.Uint16(fieldDataP)) - 2 //to ignore 2 bytes
 			fieldDataP.next(2)                                         //ignoring 2 bytes
 			dest[field_lf] = ""

--- a/encode.go
+++ b/encode.go
@@ -92,7 +92,7 @@ func binaryDecode(parameterStatus *parameterStatus, s []byte, typ oid.Oid) inter
 
 func textDecode(parameterStatus *parameterStatus, s []byte, typ oid.Oid) interface{} {
 	switch typ {
-	case oid.T_char, oid.T_bpchar, oid.T_varchar, oid.T_nvarchar, oid.T_text, oid.T_name, oid.T_oid:
+	case oid.T_char, oid.T_bpchar, oid.T_varchar, oid.T_nvarchar, oid.T_text, oid.T_name, oid.T_oid, oid.T_json, oid.T_jsonb:
 		return string(s)
 	case oid.T_bytea:
 		b, err := parseBytea(s)

--- a/encode.go
+++ b/encode.go
@@ -92,7 +92,7 @@ func binaryDecode(parameterStatus *parameterStatus, s []byte, typ oid.Oid) inter
 
 func textDecode(parameterStatus *parameterStatus, s []byte, typ oid.Oid) interface{} {
 	switch typ {
-	case oid.T_char, oid.T_bpchar, oid.T_varchar, oid.T_nvarchar, oid.T_text, oid.T_name, oid.T_oid, oid.T_json, oid.T_jsonb:
+	case oid.T_char, oid.T_bpchar, oid.T_varchar, oid.T_nvarchar, oid.T_text, oid.T_name, oid.T_oid, oid.T_json, oid.T_jsonb, oid.T_jsonpath:
 		return string(s)
 	case oid.T_bytea:
 		b, err := parseBytea(s)

--- a/encode.go
+++ b/encode.go
@@ -92,7 +92,7 @@ func binaryDecode(parameterStatus *parameterStatus, s []byte, typ oid.Oid) inter
 
 func textDecode(parameterStatus *parameterStatus, s []byte, typ oid.Oid) interface{} {
 	switch typ {
-	case oid.T_char, oid.T_bpchar, oid.T_varchar, oid.T_nvarchar, oid.T_text, oid.T_name, oid.T_oid, oid.T_json:
+	case oid.T_char, oid.T_bpchar, oid.T_varchar, oid.T_nvarchar, oid.T_text, oid.T_name, oid.T_oid, oid.T_json, oid.T_jsonb:
 		return string(s)
 	case oid.T_bytea:
 		b, err := parseBytea(s)

--- a/encode.go
+++ b/encode.go
@@ -92,7 +92,7 @@ func binaryDecode(parameterStatus *parameterStatus, s []byte, typ oid.Oid) inter
 
 func textDecode(parameterStatus *parameterStatus, s []byte, typ oid.Oid) interface{} {
 	switch typ {
-	case oid.T_char, oid.T_bpchar, oid.T_varchar, oid.T_nvarchar, oid.T_text, oid.T_name, oid.T_oid, oid.T_json, oid.T_jsonb:
+	case oid.T_char, oid.T_bpchar, oid.T_varchar, oid.T_nvarchar, oid.T_text, oid.T_name, oid.T_oid, oid.T_json:
 		return string(s)
 	case oid.T_bytea:
 		b, err := parseBytea(s)

--- a/oid/types.go
+++ b/oid/types.go
@@ -38,6 +38,8 @@ const (
 	T_st_geometry Oid = 2552
 	T_varbinary   Oid = 2568
 	T_unkbinary   Oid = 2569
+	T_json        Oid = 2652
+	T_jsonb       Oid = 2653
 )
 
 var TypeName = map[Oid]string{
@@ -76,5 +78,6 @@ var TypeName = map[Oid]string{
 	T_st_geometry: "ST_GEOMETRY",
 	T_varbinary:   "VARBINARY",
 	T_unkbinary:   "UNKBINARY",
+	T_json:        "JSON",
+	T_jsonb:       "JSONB",
 }
-

--- a/oid/types.go
+++ b/oid/types.go
@@ -39,6 +39,7 @@ const (
 	T_varbinary   Oid = 2568
 	T_unkbinary   Oid = 2569
 	T_json        Oid = 2652
+	T_jsonb       Oid = 2653
 )
 
 var TypeName = map[Oid]string{
@@ -78,4 +79,5 @@ var TypeName = map[Oid]string{
 	T_varbinary:   "VARBINARY",
 	T_unkbinary:   "UNKBINARY",
 	T_json:        "JSON",
+	T_jsonb:       "JSONB",
 }

--- a/oid/types.go
+++ b/oid/types.go
@@ -40,6 +40,7 @@ const (
 	T_unkbinary   Oid = 2569
 	T_json        Oid = 2652
 	T_jsonb       Oid = 2653
+	T_jsonpath    Oid = 2654
 )
 
 var TypeName = map[Oid]string{
@@ -80,4 +81,5 @@ var TypeName = map[Oid]string{
 	T_unkbinary:   "UNKBINARY",
 	T_json:        "JSON",
 	T_jsonb:       "JSONB",
+	T_jsonpath:    "JSONPATH",
 }

--- a/oid/types.go
+++ b/oid/types.go
@@ -39,7 +39,6 @@ const (
 	T_varbinary   Oid = 2568
 	T_unkbinary   Oid = 2569
 	T_json        Oid = 2652
-	T_jsonb       Oid = 2653
 )
 
 var TypeName = map[Oid]string{
@@ -79,5 +78,4 @@ var TypeName = map[Oid]string{
 	T_varbinary:   "VARBINARY",
 	T_unkbinary:   "UNKBINARY",
 	T_json:        "JSON",
-	T_jsonb:       "JSONB",
 }

--- a/testInterfaces_test.go
+++ b/testInterfaces_test.go
@@ -24,10 +24,14 @@ const (
 )
 
 func openTestConnConninfo(conninfostr string) (*sql.DB, error) {
+	elog := PDALogger{"DEBUG", ""}
+	elog.Initialize()
 	return sql.Open("nzgo", conninfostr)
 }
 
 func TestNewConnector_WorksWithOpenDB(t *testing.T) {
+	elog := PDALogger{"DEBUG", ""}
+	elog.Initialize()
 	name := conninfo
 	c, err := NewConnector(name)
 	if err != nil {
@@ -46,6 +50,8 @@ func TestNewConnector_WorksWithOpenDB(t *testing.T) {
 
 func TestNewConnector_Connect(t *testing.T) {
 	fmt.Println("Interface Function check : Connect()")
+	elog := PDALogger{"DEBUG", ""}
+	elog.Initialize()
 	name := conninfo
 	c, err := NewConnector(name)
 	if err != nil {
@@ -67,6 +73,8 @@ func TestNewConnector_Connect(t *testing.T) {
 
 func TestNewConnector_Driver(t *testing.T) {
 	fmt.Println("Interface Function check : Driver()")
+	elog := PDALogger{"DEBUG", ""}
+	elog.Initialize()
 	name := conninfo
 	c, err := NewConnector(name)
 	if err != nil {

--- a/testInterfaces_test.go
+++ b/testInterfaces_test.go
@@ -530,13 +530,17 @@ func drop(db *sql.DB, table table) {
 	}
 }
 
-func selectAll(db *sql.DB, table table) {
-	sqlStatement := fmt.Sprintf(`SELECT * FROM %v`, table.name)
+func _select(db *sql.DB, table table, sqlStatement string) {
 	fmt.Println(sqlStatement)
 	rows, err := db.Query(sqlStatement)
 	checkErr(err)
 	defer rows.Close()
 	printTable(rows)
+}
+
+func selectAll(db *sql.DB, table table) {
+	sqlStatement := fmt.Sprintf(`SELECT * FROM %v`, table.name)
+	_select(db, table, sqlStatement)
 }
 
 func selectWithJsonOper(db *sql.DB, table table, oper string) {
@@ -546,11 +550,17 @@ func selectWithJsonOper(db *sql.DB, table table, oper string) {
 		oper,
 		table.name,
 	)
-	fmt.Println(sqlStatement)
-	rows, err := db.Query(sqlStatement)
-	checkErr(err)
-	defer rows.Close()
-	printTable(rows)
+	_select(db, table, sqlStatement)
+}
+
+func selectWithJsonFunc(db *sql.DB, table table, f string) {
+	sqlStatement := fmt.Sprintf(`SELECT %v, %v(%v) FROM %v`,
+		table.cols[0].name,
+		f,
+		table.cols[1].name,
+		table.name,
+	)
+	_select(db, table, sqlStatement)
 }
 
 func printTable(rows *sql.Rows) {
@@ -632,6 +642,7 @@ func _TestJson(table table) {
 		selectWithJsonOper(db, table, `>=  '{"言語":"日本語"}'`)
 		selectWithJsonOper(db, table, `<   '{"言語":"日本語"}'`)
 		selectWithJsonOper(db, table, `<=  '{"言語":"日本語"}'`)
+		selectWithJsonFunc(db, table, `jsonb_pretty`)
 	}
 	fmt.Println("")
 }

--- a/testInterfaces_test.go
+++ b/testInterfaces_test.go
@@ -14,12 +14,12 @@ const (
 	conninfo = "user=admin " +
 		"port=5480 " +
 		"password=password " +
-		"dbname=db2 " +
+		"dbname=system " +
 		//"host=9.32.247.36 " +
 		//"securityLevel=1 " +
 		//"sslmode=disable"
-		"host=vmnps-dw31.svl.ibm.com " +
-		"securityLevel=3 " +
+		"host=192.168.1.40 " +
+		"securityLevel=0 " +
 		"sslmode=require" //verify-ca sslrootcert=C:/Users/sandeep_pawar/postgresql/root31.crt"
 )
 
@@ -479,12 +479,11 @@ func TestStmt_QueryExecCloseNumInput(t *testing.T) {
 }
 
 const (
-	JSON  int = 0
-	JSONB int = 1
-	INT   int = 2
+	JSON int = 0
+	INT  int = 1
 )
 
-type jsonbRow struct {
+type jsonRow struct {
 	id   sql.NullInt32
 	json sql.NullString
 }
@@ -553,23 +552,13 @@ func selectWithJsonOper(db *sql.DB, table table, oper string) {
 	_select(db, table, sqlStatement)
 }
 
-func selectWithJsonFunc(db *sql.DB, table table, f string) {
-	sqlStatement := fmt.Sprintf(`SELECT %v, %v(%v) FROM %v`,
-		table.cols[0].name,
-		f,
-		table.cols[1].name,
-		table.name,
-	)
-	_select(db, table, sqlStatement)
-}
-
 func printTable(rows *sql.Rows) {
 	columns, err := rows.Columns()
 	fmt.Printf("%3v | %v\n", columns[0], columns[1])
 	fmt.Printf("----+----------------------------------\n")
 	for rows.Next() {
 		checkErr(rows.Err())
-		row := jsonbRow{}
+		row := jsonRow{}
 		err = rows.Scan(
 			&row.id,
 			&row.json,
@@ -584,8 +573,6 @@ func type2Str(typ int) string {
 	switch typ {
 	case JSON:
 		return "JSON"
-	case JSONB:
-		return "JSONB"
 	case INT:
 		return "INT"
 	default:
@@ -618,39 +605,7 @@ func _TestJson(table table) {
 	insert(db, table, 4, `'{"言語":"アラビア語"}'`)
 	insert(db, table, 5, `'{"言語":"Tiếng Việt"}'`)
 	selectAll(db, table)
-	selectWithJsonOper(db, table, `->  '言語'`)
-	selectWithJsonOper(db, table, `->> '言語'`)
-	selectWithJsonOper(db, table, `->  'Non-existent key'`)
-	selectWithJsonOper(db, table, `->> 'Non-existent key'`)
-	if table.cols[1].typ == JSONB {
-		selectWithJsonOper(db, table, `||  '{"cómo estás":"お元気ですか"}'`)
-		selectWithJsonOper(db, table, `-   '言語'::NVARCHAR(100)`)
-		selectWithJsonOper(db, table, `-   '"言語"'`)
-		selectWithJsonOper(db, table, `-   '["言語", "Non-existent key"]'`)
-		selectWithJsonOper(db, table, `?   '言語'`)
-		selectWithJsonOper(db, table, `?   'Non-existent key'`)
-		selectWithJsonOper(db, table, `?|  '["言語", "Non-existent key"]'`)
-		selectWithJsonOper(db, table, `?|  '["Non-existent key 1", "Non-existent key 2"]'`)
-		selectWithJsonOper(db, table, `?&  '["言語", "Non-existent key"]'`)
-		selectWithJsonOper(db, table, `?&  '["言語", "言語"]'`)
-		selectWithJsonOper(db, table, `@>  '{"言語":"日本語"}'`)
-		selectWithJsonOper(db, table, `<@  '{"言語":"日本語"}'`)
-		selectWithJsonOper(db, table, `=   '{"言語":"日本語"}'`)
-		selectWithJsonOper(db, table, `!=  '{"言語":"日本語"}'`)
-		selectWithJsonOper(db, table, `<>  '{"言語":"日本語"}'`)
-		selectWithJsonOper(db, table, `>   '{"言語":"日本語"}'`)
-		selectWithJsonOper(db, table, `>=  '{"言語":"日本語"}'`)
-		selectWithJsonOper(db, table, `<   '{"言語":"日本語"}'`)
-		selectWithJsonOper(db, table, `<=  '{"言語":"日本語"}'`)
-		selectWithJsonFunc(db, table, `jsonb_pretty`)
-	}
 	fmt.Println("")
-}
-
-func TestJsonb(t *testing.T) {
-	fmt.Println("Datatype Test: JSONB")
-	table := table{"jsonb_table", []column{{INT, "id"}, {JSONB, "jsonb_col"}}}
-	_TestJson(table)
 }
 
 func TestJson(t *testing.T) {

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package nzgo
 
 // this is the version of nzgo driver
-const nzgo_client_version = "Release 11.0.3.0"
+const nzgo_client_version = "Release 11.0.5.0"

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package nzgo
 
 // this is the version of nzgo driver
-const nzgo_client_version = "Release 11.0.5.0"
+const nzgo_client_version = "Release 11.0.3.0"

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package nzgo
 
-// this is the version of nzgo driver
+// this is version of nzgo driver
 const nzgo_client_version = "Release 11.1.0.0"

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package nzgo
 
 // this is the version of nzgo driver
-const nzgo_client_version = "Release 11.0.5.0"
+const nzgo_client_version = "Release 11.1.0.0"

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package nzgo
 
-// this is version of nzgo driver
-const nzgo_client_version = "11.0.0.0"
+// this is the version of nzgo driver
+const nzgo_client_version = "Release 11.0.5.0"


### PR DESCRIPTION
Jira:
https://jsw.ibm.com/browse/NEXTGEN-1422

Problem:

Two new datatypes were/will be introduced to IPS: JSON (introduced in IPS 11.0.3.0) and JSONB (to be introduced in soon). The support of these two datatypes on the server-side requires some changes on the client-side so it can retrieve JSON/JSONB data from the server. Specifically, there are two major changes required:

Solution:

1. Enabling nzgo client to send its client version string `Release 11.1.0.0`' to the server at the beginning of each session, which tells the server that nzgo client is capable of handling JSON/ JSONB data. Notice: the client version string must start with a string, such as 'Release', in order for the server to properly parse it.
2. Mapping JSON/JSONB data to string type in nzgo, which can be handled in a similar fashion as NVARCHAR data in nzgo.

Testing:

Tests can be invoked by `go test -run TestJson`, which triggers tests for both JSON and JSONB datatype.