### PR TITLE
Fix NPS version format in nzgo

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package nzgo
 
 // this is version of nzgo driver
-const nzgo_client_version = "11.0.0.0"
+const nzgo_client_version = "Release 11.0.0.0"


### PR DESCRIPTION
Problem:
`nzgo_client_version` is missing a mandatory word before the version number. This causes the server to fail to parse nzgo's client version.

Solution:
Add the word `"Release"` to the beginning of the  client version string `nzgo_client_version`