### PR TITLE
Changes to avoid panic with parameterized query

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1481,7 +1481,7 @@ func (cn *conn) query(query string, args []driver.Value) (_ *rows, err error) {
 		return rows, nil
 	}
 	st := cn.prepareTo(query, "")
-	st.exec(args)
+	st.Query(args)
 	return &rows{
 		cn:         cn,
 		rowsHeader: st.rowsHeader,


### PR DESCRIPTION
Issue/Jira #23 

**Problem:**
A parameterized query was getting error:
```
panic: Unknown response for simple exec: 'P' [recovered]
        panic: unknown error: "Unknown response for simple exec: 'P'"
```
Attached log file
[nzgolang_nz24552.log](https://github.com/IBM/nzgo/files/6236378/nzgolang_nz24552.log)

In case of parameterized query, function `func (cn *conn) query` calls `func (st *stmt) exec` which processes query arguments and calls `func (cn *conn) simpleExec` which is not expected in case of select query.

**Solution:**
Select query should be processed through simpleQuery routine. Hence, modified initial call `st.exec(args)` with `st.Query(args)` which now processes query though simpleQuery routine.

**Testing:**
Tested parameterized query execution.
Attached log file
[nzgolang_nz18601.log](https://github.com/IBM/nzgo/files/6236591/nzgolang_nz18601.log)
