### PR TITLE
Changes to avoid extra zero byte at the end of string

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -2717,7 +2717,6 @@ func (res *rows) Res_read_dbos_tuple(dest []driver.Value) {
 			byteBuf := make([]byte, fldlen)
 			copy(byteBuf, fieldDataP.next(fldlen)) //make a copy
 
-			byteBuf = append(byteBuf, 0)
 			dest[field_lf] = string(byteBuf)
 			elog.Debugf(chopPath(funName()), "field=%d, datatype=CHAR, value=%s, len=%d ", cur_field+1, dest[field_lf], fldlen)
 
@@ -2734,7 +2733,6 @@ func (res *rows) Res_read_dbos_tuple(dest []driver.Value) {
 				byteBuf = append(byteBuf, ' ')
 				cursize++
 			}
-			byteBuf = append(byteBuf, 0)
 			dest[field_lf] = string(byteBuf)
 			elog.Debugf(chopPath(funName()), "field=%d, datatype=%s, value=%s, len=%d ", cur_field+1, dataType[fldtype], dest[field_lf], fldlen)
 
@@ -2756,7 +2754,6 @@ func (res *rows) Res_read_dbos_tuple(dest []driver.Value) {
 			dest[field_lf] = ""
 			byteBuf := make([]byte, cursize)
 			copy(byteBuf, fieldDataP.next(cursize)) //make a copy
-			byteBuf = append(byteBuf, 0)
 
 			dest[field_lf] = string(byteBuf)
 			fldlen = cursize


### PR DESCRIPTION
Issue/Jira #26 

Problem:
When reading results of SELECT with varchar column, it always ends with an extra zero byte.

Snippet from nzgolog
`2021-04-05 06:01:08 EST [22654] [DEBUG] nzgo.(*rows).Res_read_dbos_tuple 2763 : field=1, datatype=NzTypeVarChar, value=some value without zero bytes^@, len=29`

An extra zero byte i.e NULL(`^@` symbol from the snippet above) was appended in case of varchar and few other data types.

Solution:
GO stings are not required to be NULL terminated. Hence, modified code which was appending 0 to byte buffer.

Testing:
1. SELECT with varchar column now returns string without extra zero byte. 
`2021-04-05 15:56:12 EST [26995] [DEBUG] nzgo.(*rows).Res_read_dbos_tuple 2763 : field=1, datatype=NzTypeVarChar, value=some value without zero bytes, len=29`
Attached log
[nzgolang_nz26995.log](https://github.com/IBM/nzgo/files/6264963/nzgolang_nz26995.log)


2. Tested SELECT for other affected data types.
Attached logs
[nzgolang_NzTypeNVarChar.log](https://github.com/IBM/nzgo/files/6265198/nzgolang_nz17852.log)
[nzgolang_NzTypeGeometry.log](https://github.com/IBM/nzgo/files/6265203/nzgolang_nz18725.log)
[nzgolang_NzTypeVarBinary.log](https://github.com/IBM/nzgo/files/6265209/nzgolang_nz21405.log)
[nzgolang_NzTypeJson.log](https://github.com/IBM/nzgo/files/6265213/nzgolang_nz23023.log)
[nzgolang_NzTypeJsonb.log](https://github.com/IBM/nzgo/files/6265221/nzgolang_nz32091.log)
[nzgolang_NzTypeJsonpath.log](https://github.com/IBM/nzgo/files/6265222/nzgolang_nz5033.log)
