### PR TITLE
Naming changes for PDALogger

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -27,7 +27,7 @@ Logging
 nzgo defines a simple logger interface. Set LogLevel to control logging verbosity and LogPath to specify log file path.
 In order to enable logging for the driver, you need to write below code in your application
 
-    var elog nzgo.PDALogger
+    var elog nzgo.NzLogger
     elog.LogLevel = "off"
     elog.LogPath = "C:\\Logs\\"
     elog.Initialize()

--- a/doc.go
+++ b/doc.go
@@ -27,7 +27,7 @@ Logging
 nzgo defines a simple logger interface. Set LogLevel to control logging verbosity and LogPath to specify log file path.
 In order to enable logging for the driver, you need to write below code in your application
 
-    var elog nzgo.NzLogger
+    var elog nzgo.NZLogger
     elog.LogLevel = "off"
     elog.LogPath = "C:\\Logs\\"
     elog.Initialize()

--- a/logger.go
+++ b/logger.go
@@ -18,12 +18,12 @@ var (
 )
 
 /*Valid log levels : DEBUG, INFO, FATAL, OFF*/
-type PDALogger struct {
+type NzLogger struct {
 	LogLevel string
 	LogPath  string
 }
 
-var elog PDALogger
+var elog NzLogger
 
 /* Create logger handler with some predefined prefix setting,
  * this will be overwritten in actual logging.
@@ -45,7 +45,7 @@ func Init() {
 }
 
 /* Initialize logger and set output to file */
-func (elog PDALogger) Initialize() {
+func (elog NzLogger) Initialize() {
 
 	var fname string
 	/* Overwrite log level mentioned in conf, if its blank use default case */
@@ -106,7 +106,7 @@ func prefixString() string {
 }
 
 /* Wrappers to print functions to change pefix format */
-func (elog PDALogger) Debugf(fname string, s string, args ...interface{}) {
+func (elog NzLogger) Debugf(fname string, s string, args ...interface{}) {
 	prefixStr := prefixString() + "[DEBUG] " + fname + " "
 	Debug.SetFlags(0)
 	Debug.SetPrefix(prefixStr)
@@ -115,7 +115,7 @@ func (elog PDALogger) Debugf(fname string, s string, args ...interface{}) {
 }
 
 /* Used for adding debug log without format */
-func (elog PDALogger) Debugln(args ...interface{}) {
+func (elog NzLogger) Debugln(args ...interface{}) {
 	prefixStr := prefixString() + "[DEBUG] "
 	Debug.SetFlags(0)
 	Debug.SetPrefix(prefixStr)
@@ -124,7 +124,7 @@ func (elog PDALogger) Debugln(args ...interface{}) {
 }
 
 /* Info logger adds messages for client */
-func (elog PDALogger) infof(s string, args ...interface{}) {
+func (elog NzLogger) infof(s string, args ...interface{}) {
 	prefixStr := prefixString() + "[INFO] : "
 	Info.SetFlags(0)
 	Info.SetPrefix(prefixStr)
@@ -132,7 +132,7 @@ func (elog PDALogger) infof(s string, args ...interface{}) {
 	Info.Printf(s, args...)
 }
 
-func (elog PDALogger) Infoln(args ...interface{}) {
+func (elog NzLogger) Infoln(args ...interface{}) {
 	prefixStr := prefixString() + "[INFO] : "
 	Info.SetFlags(0)
 	Info.SetPrefix(prefixStr)
@@ -141,7 +141,7 @@ func (elog PDALogger) Infoln(args ...interface{}) {
 }
 
 /* Fatal logs error and panic, forcing application to exit with message on stdout */
-func (elog PDALogger) Fatalf(fname string, s string, args ...interface{}) {
+func (elog NzLogger) Fatalf(fname string, s string, args ...interface{}) {
 	prefixStr := prefixString() + "[FATAL] " + fname + " "
 	Fatal.SetFlags(0)
 	Fatal.SetPrefix(prefixStr)
@@ -149,7 +149,7 @@ func (elog PDALogger) Fatalf(fname string, s string, args ...interface{}) {
 	Fatal.Panic(fmt.Sprintf(s, args...))
 }
 
-func (elog PDALogger) Fatalln(args ...interface{}) {
+func (elog NzLogger) Fatalln(args ...interface{}) {
 	prefixStr := prefixString() + "[FATAL] "
 	Fatal.SetFlags(0)
 	Fatal.SetPrefix(prefixStr)

--- a/logger.go
+++ b/logger.go
@@ -18,12 +18,12 @@ var (
 )
 
 /*Valid log levels : DEBUG, INFO, FATAL, OFF*/
-type NzLogger struct {
+type NZLogger struct {
 	LogLevel string
 	LogPath  string
 }
 
-var elog NzLogger
+var elog NZLogger
 
 /* Create logger handler with some predefined prefix setting,
  * this will be overwritten in actual logging.
@@ -45,7 +45,7 @@ func Init() {
 }
 
 /* Initialize logger and set output to file */
-func (elog NzLogger) Initialize() {
+func (elog NZLogger) Initialize() {
 
 	var fname string
 	/* Overwrite log level mentioned in conf, if its blank use default case */
@@ -106,7 +106,7 @@ func prefixString() string {
 }
 
 /* Wrappers to print functions to change pefix format */
-func (elog NzLogger) Debugf(fname string, s string, args ...interface{}) {
+func (elog NZLogger) Debugf(fname string, s string, args ...interface{}) {
 	prefixStr := prefixString() + "[DEBUG] " + fname + " "
 	Debug.SetFlags(0)
 	Debug.SetPrefix(prefixStr)
@@ -115,7 +115,7 @@ func (elog NzLogger) Debugf(fname string, s string, args ...interface{}) {
 }
 
 /* Used for adding debug log without format */
-func (elog NzLogger) Debugln(args ...interface{}) {
+func (elog NZLogger) Debugln(args ...interface{}) {
 	prefixStr := prefixString() + "[DEBUG] "
 	Debug.SetFlags(0)
 	Debug.SetPrefix(prefixStr)
@@ -124,7 +124,7 @@ func (elog NzLogger) Debugln(args ...interface{}) {
 }
 
 /* Info logger adds messages for client */
-func (elog NzLogger) infof(s string, args ...interface{}) {
+func (elog NZLogger) infof(s string, args ...interface{}) {
 	prefixStr := prefixString() + "[INFO] : "
 	Info.SetFlags(0)
 	Info.SetPrefix(prefixStr)
@@ -132,7 +132,7 @@ func (elog NzLogger) infof(s string, args ...interface{}) {
 	Info.Printf(s, args...)
 }
 
-func (elog NzLogger) Infoln(args ...interface{}) {
+func (elog NZLogger) Infoln(args ...interface{}) {
 	prefixStr := prefixString() + "[INFO] : "
 	Info.SetFlags(0)
 	Info.SetPrefix(prefixStr)
@@ -141,7 +141,7 @@ func (elog NzLogger) Infoln(args ...interface{}) {
 }
 
 /* Fatal logs error and panic, forcing application to exit with message on stdout */
-func (elog NzLogger) Fatalf(fname string, s string, args ...interface{}) {
+func (elog NZLogger) Fatalf(fname string, s string, args ...interface{}) {
 	prefixStr := prefixString() + "[FATAL] " + fname + " "
 	Fatal.SetFlags(0)
 	Fatal.SetPrefix(prefixStr)
@@ -149,7 +149,7 @@ func (elog NzLogger) Fatalf(fname string, s string, args ...interface{}) {
 	Fatal.Panic(fmt.Sprintf(s, args...))
 }
 
-func (elog NzLogger) Fatalln(args ...interface{}) {
+func (elog NZLogger) Fatalln(args ...interface{}) {
 	prefixStr := prefixString() + "[FATAL] "
 	Fatal.SetFlags(0)
 	Fatal.SetPrefix(prefixStr)

--- a/testInterfaces_test.go
+++ b/testInterfaces_test.go
@@ -23,13 +23,13 @@ const (
 )
 
 func openTestConnConninfo(conninfostr string) (*sql.DB, error) {
-	elog := PDALogger{"DEBUG", ""}
+	elog := NzLogger{"DEBUG", ""}
 	elog.Initialize()
 	return sql.Open("nzgo", conninfostr)
 }
 
 func TestNewConnector_WorksWithOpenDB(t *testing.T) {
-	elog := PDALogger{"DEBUG", ""}
+	elog := NzLogger{"DEBUG", ""}
 	elog.Initialize()
 	name := conninfo
 	c, err := NewConnector(name)
@@ -49,7 +49,7 @@ func TestNewConnector_WorksWithOpenDB(t *testing.T) {
 
 func TestNewConnector_Connect(t *testing.T) {
 	fmt.Println("Interface Function check : Connect()")
-	elog := PDALogger{"DEBUG", ""}
+	elog := NzLogger{"DEBUG", ""}
 	elog.Initialize()
 	name := conninfo
 	c, err := NewConnector(name)
@@ -72,7 +72,7 @@ func TestNewConnector_Connect(t *testing.T) {
 
 func TestNewConnector_Driver(t *testing.T) {
 	fmt.Println("Interface Function check : Driver()")
-	elog := PDALogger{"DEBUG", ""}
+	elog := NzLogger{"DEBUG", ""}
 	elog.Initialize()
 	name := conninfo
 	c, err := NewConnector(name)

--- a/testInterfaces_test.go
+++ b/testInterfaces_test.go
@@ -23,13 +23,13 @@ const (
 )
 
 func openTestConnConninfo(conninfostr string) (*sql.DB, error) {
-	elog := NzLogger{"DEBUG", ""}
+	elog := NZLogger{"DEBUG", ""}
 	elog.Initialize()
 	return sql.Open("nzgo", conninfostr)
 }
 
 func TestNewConnector_WorksWithOpenDB(t *testing.T) {
-	elog := NzLogger{"DEBUG", ""}
+	elog := NZLogger{"DEBUG", ""}
 	elog.Initialize()
 	name := conninfo
 	c, err := NewConnector(name)
@@ -49,7 +49,7 @@ func TestNewConnector_WorksWithOpenDB(t *testing.T) {
 
 func TestNewConnector_Connect(t *testing.T) {
 	fmt.Println("Interface Function check : Connect()")
-	elog := NzLogger{"DEBUG", ""}
+	elog := NZLogger{"DEBUG", ""}
 	elog.Initialize()
 	name := conninfo
 	c, err := NewConnector(name)
@@ -72,7 +72,7 @@ func TestNewConnector_Connect(t *testing.T) {
 
 func TestNewConnector_Driver(t *testing.T) {
 	fmt.Println("Interface Function check : Driver()")
-	elog := NzLogger{"DEBUG", ""}
+	elog := NZLogger{"DEBUG", ""}
 	elog.Initialize()
 	name := conninfo
 	c, err := NewConnector(name)


### PR DESCRIPTION
Changed PDALogger struct name to NzLogger as to make it common for PDA and NPS.