### PR TITLE
nzgo migration to Go module

### DIFF
--- a/buf.go
+++ b/buf.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 
-	"github.com/IBM/nzgo/oid"
+	"github.com/IBM/nzgo/v12/oid"
 )
 
 type readBuf []byte

--- a/conn.go
+++ b/conn.go
@@ -25,7 +25,7 @@ import (
 	"unicode"
 	"unsafe"
 
-	"github.com/IBM/nzgo/oid"
+	"github.com/IBM/nzgo/v12/oid"
 )
 
 // Common error types

--- a/encode.go
+++ b/encode.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/IBM/nzgo/oid"
+	"github.com/IBM/nzgo/v12/oid"
 )
 
 func binaryEncode(parameterStatus *parameterStatus, x interface{}) []byte {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/IBM/nzgo/v11.1.0
+module github.com/IBM/nzgo/v11
 
 go 1.14
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/IBM/nzgo/v11.1.0
+
+go 1.14
+
+require github.com/IBM/nzgo v11.1.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
-module github.com/IBM/nzgo/v11
+module github.com/IBM/nzgo/v12
 
 go 1.14
-
-require github.com/IBM/nzgo v11.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/IBM/nzgo v11.1.0+incompatible h1:CaaDdlBodPo+ZiHuMMWBpfSQlSH88/nxCzsdCnQRbAA=
-github.com/IBM/nzgo v11.1.0+incompatible/go.mod h1:n1QK6KJjNa8fe+HQPynW+mJpRpkffLXMO8LR9Nja0JU=

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/IBM/nzgo v11.1.0+incompatible h1:CaaDdlBodPo+ZiHuMMWBpfSQlSH88/nxCzsdCnQRbAA=
+github.com/IBM/nzgo v11.1.0+incompatible/go.mod h1:n1QK6KJjNa8fe+HQPynW+mJpRpkffLXMO8LR9Nja0JU=

--- a/oid/gen.go
+++ b/oid/gen.go
@@ -12,7 +12,7 @@ import (
 	"os/exec"
 	"strings"
 
-	_ "github.com/IBM/nzgo"
+	_ "github.com/IBM/nzgo/v12"
 )
 
 // OID represent a postgres Object Identifier Type.

--- a/rows.go
+++ b/rows.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/IBM/nzgo/oid"
+	"github.com/IBM/nzgo/v12/oid"
 )
 
 const headerSize = 4


### PR DESCRIPTION
**Problem:**
While installing nzgo with GO111MODULE="on" i.e in module aware mode, it shows an appended `+incompatible` flag as:
```
go get github.com/IBM/nzgo
go: downloading github.com/IBM/nzgo v11.1.0+incompatible
```
This is because:

1. Starting from Go 1.16, the go command builds packages in module-aware mode by default, even when no go.mod is present.
2. nzgo current version is v11.1.0 and Go now demands to have go.mod for major v2+ with matching major version suffix in its module path, else it appends `+incompatible` flag.

**Workaround**:
nzgo can be installed by setting GO111MODULE="off" as described [here](https://github.com/IBM/nzgo/issues/28). However, Go 1.17 will drop this GOPATH mode support. 

**Solution**:
Migration to modules way:
1. Generated go.mod for nzgo with module path `github.com/IBM/nzgo/v12`
2. Replaced import paths to use above module path.

Testing:
1. Tested installation of nzgo v12.
```
    go get github.com/IBM/nzgo/v12@9d77d2d91129634b36ab757dc199a7affed56ec9
    go: downloading github.com/IBM/nzgo/v12 v12.0.0-20210527124509-9d77d2d91129
    go: github.com/IBM/nzgo/v12 9d77d2d91129634b36ab757dc199a7affed56ec9 => v12.0.0-20210527124509-9d77d2d91129
```
2. Executed all tests:
```
go test ./...
ok      github.com/IBM/nzgo/v12 7.310s
?       github.com/IBM/nzgo/v12/example/listen  [no test files]
?       github.com/IBM/nzgo/v12/hstore  [no test files]
?       github.com/IBM/nzgo/v12/oid     [no test files]

```