### PR TITLE
Add runtime error handling code while fetching records

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -2093,7 +2093,13 @@ func (res *rows) Next(dest []driver.Value) (err error) {
 			cn.recv_n_bytes(4)
 			length, _ := cn.recv_n_bytes(4)
 			responseBuf, _ := cn.recv_n_bytes(int(length.int32()))
-			elog.Fatalf(chopPath(funName()), "%s", responseBuf.string())
+			errorString := responseBuf.string()
+			err = errors.New(errorString)
+			elog.Infoln(funName(), errorString)
+			return err
+		case 'Z': /* Backend is ready for new query (6.4) */
+			return err
+
 		case 'X': //	get dbos tuple descriptor
 			cn.recv_n_bytes(4)
 			length, _ := cn.recv_n_bytes(4)

--- a/conn.go
+++ b/conn.go
@@ -2089,7 +2089,11 @@ func (res *rows) Next(dest []driver.Value) (err error) {
 			cn.saveMessage(response, &responseBuf)
 			res.readTuples(dest)
 			return
-
+		case 'E':
+			cn.recv_n_bytes(4)
+			length, _ := cn.recv_n_bytes(4)
+			responseBuf, _ := cn.recv_n_bytes(int(length.int32()))
+			elog.Fatalf(chopPath(funName()), "%s", responseBuf.string())
 		case 'X': //	get dbos tuple descriptor
 			cn.recv_n_bytes(4)
 			length, _ := cn.recv_n_bytes(4)


### PR DESCRIPTION
With the recent feature of allowing multi-JSONB projections, which checks the rowsize length overflow at the run-time, all drivers need to comply with the new behavior. Few drivers had to be modified, while others worked as is out of the box. Nzgo driver needs to be updated to handle this new behavior, since now the prepare time checks have been postponed until fetch time.

Note: I'm not sure if calling elog.Fatalf() is appropriate here since it is producing a full stack instead of a simple error as at prep time, so please free to suggest a different approach as you see fit.