### PR TITLE
Default log level to Info and support for additional log file

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -53,7 +53,7 @@ func (elog NZLogger) Initialize() {
 		elog.LogLevel = strings.ToUpper(elog.LogLevel)
 	} else {
 		/* Set loglevel here, invalid loglevel will discard all log messages */
-		elog.LogLevel = "DEBUG" //This is default log level
+		elog.LogLevel = "INFO" //This is default log level
 	}
 
 	/* If Loglevel is OFF or anything other than DEBUG INFO OR FATAL then no log file would be created */


### PR DESCRIPTION
**Problem:**
1. Set default log level to info instead of Debug
2. Add support for additional log file

**Solution:**

1.
Default log level changes to Info.
If no log level is mentioned INFO will be considered.

2.
User can mention addition logfile through setting LogFile to desired file with full path.
Same logs will be added to both files(logger created and LogFile).
Log level for LogFile will be the same as mentioned through LogLevel. If not mentioned its INFO.

**Supported:**
Logging OFF(LogLevel = "OFF")
Logging to only internally created logfile(LogFile is not set)
Logging in both the files(LogFile is set)

**Note:** 
Currently there is no way to disable internal logging and only write to LogFile.

