### PR TITLE
Initialize logger in conn.go when connection is getting opened

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -732,7 +732,7 @@ func parseOpts(name string, o values) error {
 
 	elog.Initialize(o["LogLevel"], o["LogPath"], o["AdditionalLogFile"])
 
-	elog.Infoln("Setup : ", name, o)
+	elog.Infoln("Setup Config: ", o)
 	return nil
 }
 

--- a/conn.go
+++ b/conn.go
@@ -730,7 +730,7 @@ func parseOpts(name string, o values) error {
 		o[string(keyRunes)] = string(valRunes)
 	}
 
-	elog.Initialize(o["LogLevel"], o["LogPath"], o["LogFile"])
+	elog.Initialize(o["LogLevel"], o["LogPath"], o["AdditionalLogFile"])
 
 	elog.Infoln("Setup : ", name, o)
 	return nil

--- a/conn.go
+++ b/conn.go
@@ -730,7 +730,7 @@ func parseOpts(name string, o values) error {
 		o[string(keyRunes)] = string(valRunes)
 	}
 
-	elog.Initialize(o["LogLevel"], o["LogPath"], o["AdditionalLogFile"])
+	elog.Initialize(o["logLevel"], o["logPath"], o["additionalLogFile"])
 
 	return nil
 }

--- a/conn.go
+++ b/conn.go
@@ -269,13 +269,6 @@ const (
 	NPSCLIENT_TYPE_GOLANG = 12
 )
 
-//Configuration setup
-type Configuration struct {
-	LogLevel string
-}
-
-var configuration Configuration
-
 // Driver is the Postgres database driver.
 type Driver struct{}
 
@@ -665,7 +658,6 @@ func (s *scanner) SkipSpaces() (rune, bool) {
 //
 // The parsing code is based on conninfo_parse from libpq's fe-connect.c
 func parseOpts(name string, o values) error {
-	elog.Infoln("Setup : ", name, o)
 	s := newScanner(name)
 
 	for {
@@ -738,6 +730,9 @@ func parseOpts(name string, o values) error {
 		o[string(keyRunes)] = string(valRunes)
 	}
 
+	elog.Initialize(o["LogLevel"], o["LogPath"], o["LogFile"])
+
+	elog.Infoln("Setup : ", name, o)
 	return nil
 }
 

--- a/conn.go
+++ b/conn.go
@@ -732,7 +732,6 @@ func parseOpts(name string, o values) error {
 
 	elog.Initialize(o["LogLevel"], o["LogPath"], o["AdditionalLogFile"])
 
-	elog.Infoln("Setup Config: ", o)
 	return nil
 }
 
@@ -1731,7 +1730,6 @@ func (cn *conn) startup(o values) (err error) {
 	// user we want to connect as.  Additionally, we send over any run-time
 	// parameters potentially included in the connection string.  If the server
 	// doesn't recognize any of them, it will reply with an error.
-	elog.Infoln("Backend setting info ", o)
 	elog.Infoln("Starting handshake negotiation with server")
 	versionPacket := HsVersion{
 		opcode:  HSV2_CLIENT_BEGIN,

--- a/logger.go
+++ b/logger.go
@@ -49,7 +49,7 @@ func Init() {
 func (elog NZLogger) Initialize(logLevel, logPath, additionalLogFile string) {
 	elog.LogLevel = logLevel
 	elog.LogPath = logPath
-	elog.AdditionalLogFile = logFile
+	elog.AdditionalLogFile = additionalLogFile
 
 	var fname string
 	/* Overwrite log level mentioned in conf, if its blank use default case */
@@ -78,8 +78,8 @@ func (elog NZLogger) Initialize(logLevel, logPath, additionalLogFile string) {
 		errorf("Error opening logger file")
 	}
 	var additionalFh *os.File
-	if elog.LogFile != "" {
-		additionalFh, err = os.OpenFile(elog.LogFile, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+	if elog.AdditionalLogFile != "" {
+		additionalFh, err = os.OpenFile(elog.AdditionalLogFile, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
 		if err != nil {
 			errorf("Error opening logger file")
 		}

--- a/logger.go
+++ b/logger.go
@@ -46,7 +46,10 @@ func Init() {
 }
 
 /* Initialize logger and set output to file */
-func (elog NZLogger) Initialize() {
+func (elog NZLogger) Initialize(logLevel, logPath, logFile string) {
+	elog.LogLevel = logLevel
+	elog.LogPath = logPath
+	elog.LogFile = logFile
 
 	var fname string
 	/* Overwrite log level mentioned in conf, if its blank use default case */

--- a/logger.go
+++ b/logger.go
@@ -19,9 +19,9 @@ var (
 
 /*Valid log levels : DEBUG, INFO, FATAL, OFF*/
 type NZLogger struct {
-	LogLevel string
-	LogPath  string
-	LogFile  string
+	LogLevel          string
+	LogPath           string
+	AdditionalLogFile string
 }
 
 var elog NZLogger
@@ -46,10 +46,10 @@ func Init() {
 }
 
 /* Initialize logger and set output to file */
-func (elog NZLogger) Initialize(logLevel, logPath, logFile string) {
+func (elog NZLogger) Initialize(logLevel, logPath, additionalLogFile string) {
 	elog.LogLevel = logLevel
 	elog.LogPath = logPath
-	elog.LogFile = logFile
+	elog.AdditionalLogFile = logFile
 
 	var fname string
 	/* Overwrite log level mentioned in conf, if its blank use default case */


### PR DESCRIPTION
**Problem:**
It was mandatory to initialize logger in application.

**Solution:**
No need to initialize logger separately in application.
Just mention log config parameters through connection string.

**Log Config Parameters:**
1. logLevel 
INFO/DEBUG/FATAL/OFF

2. logPath
Path for log file creation

3. additionalLogFile
If additional logfile is required, provide full path of new file.

loglevel mentioned will be applicable to both the log files. Same log level messages will be written in internally created log file and in additionalLogFile.

**Note**
Not mentioning any log config parameters will create log file in current directory.

--------------
**Sample Example:**

```
package main

import (
	"database/sql"
	"fmt"
	"os"

	_ "github.com/IBM/nzgo"
)

func main() {
	host := "localhost"
	password := "password"
	securityLevel := "0"
	sslmode := "disable"

	var conninfo string = "user=admin " +
		"port=5480 " +
		"password=" + password + " " +
		"dbname=system " +
		"host=" + host + " " +
		"securityLevel= " + securityLevel + " " +
		"sslmode=" + sslmode + " " +
		"logLevel=info" + " " +
		"logPath=/workspaces/" + " " +
		"additionalLogFile=/workspaces/spawar72/nzgo/samples/tst2.log"

	fmt.Println("Connection String : " + conninfo)
	db, err := sql.Open("nzgo", conninfo)
	if err != nil {
		panic(err)
	}
	defer db.Close()
	fmt.Println("Basic Checks")

	db.Exec("drop table t1 if exists")
	db.Exec("CREATE TABLE t1 (id int, a numeric(10,5), b varchar(10), c char(10))")
	db.Exec("INSERT INTO t1 VALUES (1,12345.43567899,'123887890','1234567890')")

	fmt.Println("Successfully connected!")
}
```
Log Files created:
```
/workspaces/spawar72/nzgo/samples> ls -l | grep *.log
-rw-r--r-- 1 nz nz    2429 Jul 13 11:52 tst2.log

/workspaces/spawar72/nzgo/samples> ls -l /workspaces/*.log
-rw-r--r-- 1 nz nz 2429 Jul 13 12:10 /workspaces/nzgolang_nz14714.log
```

On windows, tested with:
```
host := "sim-rh28.fyre.ibm.com"
"additionalLogFile=C:/Users/SandeepPawar/Desktop/tst2.log" + " " +
"logPath=D:/"

PS C:\Users\SandeepPawar\Desktop> ls D:/nzg*
    Directory: D:\
Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a----        13-07-2021     18:25           1116 nzgolang_nz18296.log

PS C:\Users\SandeepPawar\Desktop> ls *.log
    Directory: C:\Users\SandeepPawar\Desktop
Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a----        13-07-2021     18:25           1116 tst2.log




```
