### PR TITLE
Handle notice in auth

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -2967,15 +2967,15 @@ func (cn *conn) Conn_processAuthResponse() bool {
 
 		case 'N':
 			cn.recv_n_bytes(4) // ignore first 4 bytes
-                        x, _ := cn.recv_n_bytes(4)
-   		        len := x.int32()
-                        elog.Debugf(chopPath(funName()), "Backend message(Notice) length %d\n", len)
+			x, _ := cn.recv_n_bytes(4)
+			len := x.int32()
+			elog.Debugf(chopPath(funName()), "Backend message(Notice) length %d\n", len)
 
-                        responseBuf, _ := cn.recv_n_bytes(len)
-                        notice := &rows{cn: cn}
-                        notice.noticetag = responseBuf.string()
-                        elog.Infof(chopPath(funName()), "Message(Notice) received %s\n", notice.noticetag)
-		
+			responseBuf, _ := cn.recv_n_bytes(len)
+			notice := &rows{cn: cn}
+			notice.noticetag = responseBuf.string()
+			elog.Infof(chopPath(funName()), "Message(Notice) received %s\n", notice.noticetag)
+
 		default:
 			elog.Fatalf(chopPath(funName()), "Unexpected response: %q", t)
 			res = false

--- a/logger.go
+++ b/logger.go
@@ -147,8 +147,8 @@ func (elog NZLogger) Debugln(args ...interface{}) {
 }
 
 /* Info logger adds messages for client */
-func (elog NZLogger) infof(s string, args ...interface{}) {
-	prefixStr := prefixString() + "[INFO] : "
+func (elog NZLogger) Infof(fname string, s string, args ...interface{}) {
+	prefixStr := prefixString() + "[INFO] " + fname + " "
 	Info.SetFlags(0)
 	Info.SetPrefix(prefixStr)
 
@@ -156,7 +156,7 @@ func (elog NZLogger) infof(s string, args ...interface{}) {
 }
 
 func (elog NZLogger) Infoln(args ...interface{}) {
-	prefixStr := prefixString() + "[INFO] : "
+	prefixStr := prefixString() + "[INFO] "
 	Info.SetFlags(0)
 	Info.SetPrefix(prefixStr)
 


### PR DESCRIPTION
**Issue:** https://github.com/IBM/nzgo/issues/41
**Problem:**
Unhandled case - Server sends notice while authentication.


**Solution:**
Notice handled properly by adding case for backend response 'N' in connection authentication step.



Before
```
2021-07-16 05:19:51 EST [17647] [DEBUG] nzgo.(*conn).Conn_processAuthResponse 2939 : Backend response  R
2021-07-16 05:19:51 EST [17647] [DEBUG] nzgo.(*conn).Conn_processAuthResponse 2947 : Backend response  0
2021-07-16 05:19:51 EST [17647] [DEBUG] nzgo.(*conn).Conn_processAuthResponse 2939 : Backend response  N
2021-07-16 05:19:51 EST [17647] [FATAL] nzgo.(*conn).Conn_processAuthResponse 2968 : Unexpected response: 'N'
```

After
```
2021-07-16 08:03:09 EST [28654] [DEBUG] nzgo.(*conn).Conn_processAuthResponse 2939 : Backend response  R
2021-07-16 08:03:09 EST [28654] [DEBUG] nzgo.(*conn).Conn_processAuthResponse 2947 : Backend response  0
2021-07-16 08:03:09 EST [28654] [DEBUG] nzgo.(*conn).Conn_processAuthResponse 2939 : Backend response  N
2021-07-16 08:03:09 EST [28654] [DEBUG] nzgo.(*conn).Conn_processAuthResponse 2972 : Backend message(Notice) length 65
2021-07-16 08:03:09 EST [28654] [INFO] nzgo.(*conn).Conn_processAuthResponse 2977 : Message(Notice) received NOTICE:  SET PATH: unable to locate the schema / database 'DB2'

2021-07-16 08:03:09 EST [28654] [DEBUG] nzgo.(*conn).Conn_processAuthResponse 2939 : Backend response  K
2021-07-16 08:03:09 EST [28654] [DEBUG] nzgo.(*conn).Conn_processAuthResponse 2953 : Backend response PID  18646
2021-07-16 08:03:09 EST [28654] [DEBUG] nzgo.(*conn).Conn_processAuthResponse 2956 : Backend response KEY  1369490012
2021-07-16 08:03:09 EST [28654] [DEBUG] nzgo.(*conn).Conn_processAuthResponse 2939 : Backend response  Z
2021-07-16 08:03:09 EST [28654] [DEBUG] nzgo.(*conn).Conn_processAuthResponse 2959 : Authentication Successful
```
