### PR TITLE
Updating Initialize() methods receiver as pointer

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -24,7 +24,7 @@ type NZLogger struct {
 	AdditionalLogFile string
 }
 
-var elog NZLogger
+var elog *NZLogger = &NZLogger{}
 
 /* Create logger handler with some predefined prefix setting,
  * this will be overwritten in actual logging.
@@ -46,7 +46,7 @@ func Init() {
 }
 
 /* Initialize logger and set output to file */
-func (elog NZLogger) Initialize(logLevel, logPath, additionalLogFile string) {
+func (elog *NZLogger) Initialize(logLevel, logPath, additionalLogFile string) {
 	elog.LogLevel = logLevel
 	elog.LogPath = logPath
 	elog.AdditionalLogFile = additionalLogFile


### PR DESCRIPTION
**Issue:**
https://github.com/IBM/nzgo/issues/47

Initialize() method's receiver is passed by value;
```
Before Initialize(): {LogLevel: LogPath: AdditionalLogFile:}
---------------- IBM PDA Log -----------------
----------------------------------------------
After Initialize(): -- nothing changed --  {LogLevel: LogPath: AdditionalLogFile:}
```

**Solution:**
Updated with pass by reference instead of value.

**Test**
```
Before Initialize(): {LogLevel: LogPath: AdditionalLogFile:}
---------------- IBM PDA Log -----------------
----------------------------------------------
After Initialize(): {LogLevel:DEBUG LogPath:D:\nzgo\nzlog AdditionalLogFile:stdout}
```