### PR TITLE
Remove panic

### DIFF
--- a/buf.go
+++ b/buf.go
@@ -31,7 +31,8 @@ func (b *readBuf) int16() (n int) {
 func (b *readBuf) string() string {
 	i := bytes.IndexByte(*b, 0)
 	if i < 0 {
-		errorf("invalid message format; expected string terminator")
+		elog.Infoln(chopPath(funName()), "invalid message format; expected string terminator")
+		return ""
 	}
 	s := (*b)[:i]
 	*b = (*b)[i+1:]

--- a/conn.go
+++ b/conn.go
@@ -1168,7 +1168,8 @@ func (cn *conn) connNextResultSet(query string) (res *rows, err error) {
 	for {
 		response, err := cn.recvSingleByte()
 		if err != nil {
-			panic(err)
+			elog.Infoln(chopPath(funName()), "Error: ", err)
+			return nil, err
 		}
 		elog.Debugf(chopPath(funName()), "Backend response  %c \n", response)
 		cn.recv_n_bytes(4)
@@ -1230,7 +1231,10 @@ func (cn *conn) connNextResultSet(query string) (res *rows, err error) {
 			break
 		case 'x': /* handle Ext Tbl parser abort */
 			cn.recv_n_bytes(4)
-			elog.Fatalf(chopPath(funName()), "Error operation cancel")
+			errorString := fmt.Sprintf("Error operation cancel")
+			err = errors.New(errorString)
+			elog.Infoln(chopPath(funName()), errorString)
+			return nil, err
 			break
 		case 'e':
 			length, _ := cn.recv_n_bytes(4)
@@ -1248,7 +1252,10 @@ func (cn *conn) connNextResultSet(query string) (res *rows, err error) {
 			break
 		default:
 			cn.bad = true
-			elog.Fatalf(chopPath(funName()), "Unexpected response: %q", response)
+			errorString := fmt.Sprintf("Unexpected response: %q", response)
+			err = errors.New(errorString)
+			elog.Infoln(chopPath(funName()), errorString)
+			return nil, err
 			break
 		}
 
@@ -1291,7 +1298,8 @@ func (cn *conn) simpleQuery(query string) (res *rows, err error) {
 
 	_, err = cn.c.Write(buffer.buf)
 	if err != nil {
-		panic(err)
+		elog.Infoln(chopPath(funName()), "Error: ", err)
+		return nil, err
 	}
 
 	cn.status = CONN_EXECUTING

--- a/conn.go
+++ b/conn.go
@@ -730,7 +730,10 @@ func parseOpts(name string, o values) error {
 		o[string(keyRunes)] = string(valRunes)
 	}
 
-	elog.Initialize(o["logLevel"], o["logPath"], o["additionalLogFile"])
+	err := elog.Initialize(o["logLevel"], o["logPath"], o["additionalLogFile"])
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/conn.go
+++ b/conn.go
@@ -275,8 +275,9 @@ type Driver struct{}
 // Open opens a new connection to the database. name is a connection string.
 // Most users should only use it through database/sql package from the standard
 // library.
-func (d *Driver) Open(name string) (driver.Conn, error) {
-	return Open(name)
+func (d *Driver) Open(name string) (c driver.Conn, err error) {
+	c, err = Open(name)
+	return c, err
 }
 
 func init() {
@@ -513,7 +514,7 @@ func Open(dsn string) (_ driver.Conn, err error) {
 func DialOpen(d Dialer, dsn string) (_ driver.Conn, err error) {
 	c, err := NewConnector(dsn)
 	if err != nil {
-		return nil, elog.Fatalf(chopPath(funName()), err.Error())
+		return nil, err
 	}
 	c.dialer = d
 	return c.open(context.Background())
@@ -740,7 +741,8 @@ func parseOpts(name string, o values) error {
 
 	err := elog.Initialize(o["logLevel"], o["logPath"], o["additionalLogFile"])
 	if err != nil {
-		return elog.Fatalf(chopPath(funName()), err.Error())
+		fmt.Printf(err.Error())
+		return err
 	}
 
 	return nil

--- a/conn.go
+++ b/conn.go
@@ -741,7 +741,6 @@ func parseOpts(name string, o values) error {
 
 	err := elog.Initialize(o["logLevel"], o["logPath"], o["additionalLogFile"])
 	if err != nil {
-		fmt.Printf(err.Error())
 		return err
 	}
 
@@ -1822,7 +1821,7 @@ func (cn *conn) recvSingleByte() (t byte, err error) {
 			return data[0], elog.Fatalf(chopPath(funName()), "Single Byte Read failed; 0 bytes read")
 		}
 		if err != nil {
-			return data[0], elog.Fatalf(chopPath(funName()), "Error reading single byte : %s", err)
+			return data[0], elog.Fatalf(chopPath(funName()), "Error reading single byte : %q", err)
 		}
 		return data[0], nil
 	}
@@ -1835,7 +1834,7 @@ func (cn *conn) recv_n_bytes(n int) (r readBuf, err error) {
 		for totalRead < n {
 			nread, err := cn.c.Read(data[totalRead:]) // it reads max 1024bytes in one go. Which also has handhsake data. If large data read is getting processed this is very imp
 			if err != nil {
-				return data, elog.Fatalf(chopPath(funName()), "Error reading n bytes : ", n, err)
+				return data, elog.Fatalln(chopPath(funName()), "Error reading n bytes : ", n, err)
 			}
 			totalRead = totalRead + nread
 		}

--- a/copy.go
+++ b/copy.go
@@ -123,7 +123,7 @@ awaitCopyInResponse:
 			return nil, err
 		default:
 			ci.setBad()
-			return nil, fmt.Errorf("unknown response for CopyFail: %q", t)
+			return nil, elog.Fatalf(chopPath(funName()), "unknown response for CopyFail: %q", t)
 		}
 	}
 }
@@ -268,7 +268,7 @@ func (ci *copyin) Close() (err error) {
 	// Avoid touching the scratch buffer as resploop could be using it.
 	err = ci.cn.sendSimpleMessage('c')
 	if err != nil {
-		return err
+		return elog.Fatalf(chopPath(funName()), err.Error())
 	}
 
 	<-ci.done
@@ -276,7 +276,7 @@ func (ci *copyin) Close() (err error) {
 
 	if ci.isErrorSet() {
 		err = ci.err
-		return err
+		return elog.Fatalf(chopPath(funName()), err.Error())
 	}
 	return nil
 }

--- a/copy.go
+++ b/copy.go
@@ -98,13 +98,13 @@ awaitCopyInResponse:
 		case 'Z':
 			if err == nil {
 				ci.setBad()
-				errorf("unexpected ReadyForQuery in response to COPY")
+				return nil, fmt.Errorf("unexpected ReadyForQuery in response to COPY")
 			}
 			cn.processReadyForQuery(r)
 			return nil, err
 		default:
 			ci.setBad()
-			errorf("unknown response for copy query: %q", t)
+			return nil, fmt.Errorf("unknown response for copy query: %q", t)
 		}
 	}
 
@@ -123,7 +123,7 @@ awaitCopyInResponse:
 			return nil, err
 		default:
 			ci.setBad()
-			errorf("unknown response for CopyFail: %q", t)
+			return nil, fmt.Errorf("unknown response for CopyFail: %q", t)
 		}
 	}
 }
@@ -134,7 +134,7 @@ func (ci *copyin) flush(buf []byte) {
 
 	_, err := ci.cn.c.Write(buf)
 	if err != nil {
-		panic(err)
+		elog.Infoln(chopPath(funName()), "Error : ", err)
 	}
 }
 

--- a/hstore/hstore.go
+++ b/hstore/hstore.go
@@ -3,7 +3,6 @@ package hstore
 import (
 	"database/sql"
 	"database/sql/driver"
-	"fmt"
 	"strings"
 )
 
@@ -25,7 +24,7 @@ func hQuote(s interface{}) (string, error) {
 	case string:
 		str = v
 	default:
-		return "", fmt.Errorf("not a string or sql.NullString")
+		return "", elog.Fatalf(chopPath(funName()), "not a string or sql.NullString")
 	}
 
 	str = strings.Replace(str, "\\", "\\\\", -1)
@@ -114,11 +113,11 @@ func (h Hstore) Value() (driver.Value, error) {
 	for key, val := range h.Map {
 		keyRes, err := hQuote(key)
 		if err != nil {
-			return nil, err
+			return nil, elog.Fatalf(chopPath(funName()), err.Error())
 		}
 		valRes, err := hQuote(val)
 		if err != nil {
-			return nil, err
+			return nil, elog.Fatalf(chopPath(funName()), err.Error())
 		}
 		thispart := keyRes + "=>" + valRes
 		parts = append(parts, thispart)

--- a/hstore/hstore.go
+++ b/hstore/hstore.go
@@ -3,6 +3,7 @@ package hstore
 import (
 	"database/sql"
 	"database/sql/driver"
+	"fmt"
 	"strings"
 )
 
@@ -13,22 +14,22 @@ type Hstore struct {
 
 // escapes and quotes hstore keys/values
 // s should be a sql.NullString or string
-func hQuote(s interface{}) string {
+func hQuote(s interface{}) (string, error) {
 	var str string
 	switch v := s.(type) {
 	case sql.NullString:
 		if !v.Valid {
-			return "NULL"
+			return "NULL", nil
 		}
 		str = v.String
 	case string:
 		str = v
 	default:
-		panic("not a string or sql.NullString")
+		return "", fmt.Errorf("not a string or sql.NullString")
 	}
 
 	str = strings.Replace(str, "\\", "\\\\", -1)
-	return `"` + strings.Replace(str, "\"", "\\\"", -1) + `"`
+	return `"` + strings.Replace(str, "\"", "\\\"", -1) + `"`, nil
 }
 
 // Scan implements the Scanner interface.
@@ -111,7 +112,15 @@ func (h Hstore) Value() (driver.Value, error) {
 	}
 	parts := []string{}
 	for key, val := range h.Map {
-		thispart := hQuote(key) + "=>" + hQuote(val)
+		keyRes, err := hQuote(key)
+		if err != nil {
+			return nil, err
+		}
+		valRes, err := hQuote(val)
+		if err != nil {
+			return nil, err
+		}
+		thispart := keyRes + "=>" + valRes
 		parts = append(parts, thispart)
 	}
 	return []byte(strings.Join(parts, ",")), nil

--- a/logger.go
+++ b/logger.go
@@ -163,21 +163,23 @@ func (elog NZLogger) Infoln(args ...interface{}) {
 	Info.Println(args...)
 }
 
-/* Fatal logs error and panic, forcing application to exit with message on stdout */
-func (elog NZLogger) Fatalf(fname string, s string, args ...interface{}) {
+/* Fatal logs error and returns error*/
+func (elog NZLogger) Fatalf(fname string, s string, args ...interface{}) error {
 	prefixStr := prefixString() + "[FATAL] " + fname + " "
 	Fatal.SetFlags(0)
 	Fatal.SetPrefix(prefixStr)
 
-	Fatal.Panic(fmt.Sprintf(s, args...))
+	Fatal.Printf(s, args...)
+	return fmt.Errorf(s, args...)
 }
 
-func (elog NZLogger) Fatalln(args ...interface{}) {
-	prefixStr := prefixString() + "[FATAL] "
+func (elog NZLogger) Fatalln(fname string, args ...interface{}) error {
+	prefixStr := prefixString() + "[FATAL] " + fname + " "
 	Fatal.SetFlags(0)
 	Fatal.SetPrefix(prefixStr)
 
-	Fatal.Panic(args...)
+	Fatal.Println(args...)
+	return fmt.Errorf("", args...)
 }
 
 /* Function name is determined from caller stack at runtime

--- a/logger.go
+++ b/logger.go
@@ -46,7 +46,7 @@ func Init() {
 }
 
 /* Initialize logger and set output to file */
-func (elog *NZLogger) Initialize(logLevel, logPath, additionalLogFile string) {
+func (elog *NZLogger) Initialize(logLevel, logPath, additionalLogFile string) (err error) {
 	elog.LogLevel = logLevel
 	elog.LogPath = logPath
 	elog.AdditionalLogFile = additionalLogFile
@@ -75,7 +75,7 @@ func (elog *NZLogger) Initialize(logLevel, logPath, additionalLogFile string) {
 	/* Open file with permissions USER:read and write; GROUP&OTHERS:read */
 	fh, err := os.OpenFile(fname, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
 	if err != nil {
-		errorf("Error opening logger file")
+		return err
 	}
 	var additionalFh *os.File
 	if elog.AdditionalLogFile != "" {
@@ -85,7 +85,7 @@ func (elog *NZLogger) Initialize(logLevel, logPath, additionalLogFile string) {
 			additionalFh, err = os.OpenFile(elog.AdditionalLogFile, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
 		}
 		if err != nil {
-			errorf("Error opening logger file")
+			return err
 		}
 	}
 
@@ -112,7 +112,7 @@ func (elog *NZLogger) Initialize(logLevel, logPath, additionalLogFile string) {
 
 		// case default : //It will do nothing to discard the log output but log file with banner will be generated
 	}
-
+	return nil
 }
 
 /* Used to write banner for logger. ToDo:Add more info related to server */


### PR DESCRIPTION
Issue:
https://github.com/IBM/nzgo/issues/46

Problem:
Removing direct and indirect calls to panic
Function calls to be removed
panic()
errorf()
elog.Fatal()

Solution:
All panic() calls replaced with error handling.
errorf() was internally using panic after logging error message, its also replaced with logging error and returning to caller.

elog.Fatal(): updated definition to log received message and return error object.
Returning errors to caller is done through elog.Fatal() which will log the error message at current level and return error() to caller.