### PR TITLE
Avoid wrapping standard errors with customised error messages

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -268,7 +268,8 @@ func (ci *copyin) Close() (err error) {
 	// Avoid touching the scratch buffer as resploop could be using it.
 	err = ci.cn.sendSimpleMessage('c')
 	if err != nil {
-		return elog.Fatalf(chopPath(funName()), err.Error())
+		elog.Fatalf(chopPath(funName()), err.Error())
+		return err
 	}
 
 	<-ci.done
@@ -276,7 +277,8 @@ func (ci *copyin) Close() (err error) {
 
 	if ci.isErrorSet() {
 		err = ci.err
-		return elog.Fatalf(chopPath(funName()), err.Error())
+		elog.Fatalf(chopPath(funName()), err.Error())
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
**Issue**
https://github.com/IBM/nzgo/issues/50

**Problem**
In recent change elog.Fatalf() used to log error message and send error to caller. But in this process standard errors got unwrapped  and then after wrapping it sent as normal error message, that resulted in scenarios like https://github.com/IBM/nzgo/issues/50.

**Solution**
Avoid unwrapping and wrapping with elog.Fatalf(). Error messages logged using elog.Fatalf() and original error is sent to caller.

**Testing**

**Test File:**
```
        db, err := sql.Open("nzgo", conninfo)
        if errors.Is(err, syscall.ECONNREFUSED) {
                fmt.Println("Detected ECONNREFUSED: ", err)
                return
        }
        if err != nil {
                fmt.Println(err)
                return
        }
        defer db.Close()

        rows, err1 := db.Query("select count(*) from _t_object")
        if errors.Is(err1, syscall.ECONNREFUSED) {
                fmt.Println("Detected ECONNREFUSED: ", err1)
                return
        }
```

**Result**
```
Detected ECONNREFUSED:  dial tcp 10.11.52.71:5480: connect: connection refused
```

**In Logs**
```
2021-09-22 05:22:38 EST [98773] [FATAL] v12.(*Connector).open 550 : dial tcp 10.11.52.71:5480: connect: connection refused
```
