### PR TITLE
Replacing single quotes to double quotes during ? placeholder

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -3902,7 +3902,7 @@ func (st *stmt) exec(arg []driver.Value) (res driver.Result, commandTag string, 
 			str := fmt.Sprintf("%f", arg[i])
 			query = strings.Replace(query, placeholder, str, 1)
 		case string:
-			str := fmt.Sprintf("'%s'", arg[i])
+			str := fmt.Sprintf("\"%s\"", arg[i])
 			query = strings.Replace(query, placeholder, str, 1)
 		default:
 			return nil, placeholder, elog.Fatalf(chopPath(funName()), "unknown type of parameter")


### PR DESCRIPTION
Problem:
existing ? is replaced with single-quoted '' for string variable.

Solution:
We are replacing the ? with double-quoted ("") string variable.

Test:

Test case 1: With wrong password

```
[nz@anchovy1 script]$ go run test1.go
trying to open...
opened
Search database with name TEST9001
Unable to query :Password authentication failed for user 'ADMIN'
panic: runtime error: invalid memory address or nil pointer dereference
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x4ce4ce]

goroutine 1 [running]:
database/sql.(*Rows).close(0x0, {0x0, 0x0})
        /usr/lib/golang/src/database/sql/sql.go:3267 +0x8e
database/sql.(*Rows).Close(0xc00014bbf8)
        /usr/lib/golang/src/database/sql/sql.go:3263 +0x1d
panic({0x62a840, 0x817f20})
        /usr/lib/golang/src/runtime/panic.go:1038 +0x215
database/sql.(*Rows).Next(0x0)
        /usr/lib/golang/src/database/sql/sql.go:2944 +0x27
main.main()
        /nz/script/test1.go:34 +0x4d3
exit status 2

```

Test case 2: create a database query
```

[nz@anchovy1 script]$ go run test.go
trying to open...
opened
create a new database with name  TEST90011
```
[single_quote_replace_double_quote.txt](https://github.com/IBM/nzgo/files/8833356/single_quote_replace_double_quote.txt)
[wrong_Password_error_out.txt](https://github.com/IBM/nzgo/files/8833358/wrong_Password_error_out.txt)

