### PR TITLE
Added support for new cipher suites.

### DIFF
--- a/ssl.go
+++ b/ssl.go
@@ -15,6 +15,8 @@ const (
 	TLS1_CK_RSA_WITH_AES_128_SHA256         = 0x03c
 	TLS1_CK_ECDHE_ECDSA_WITH_AES_128_SHA256 = 0xc023
 	TLS1_CK_ECDHE_RSA_WITH_AES_128_SHA256   = 0xc027
+        TLS1_CK_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 = 0xc02c
+        TLS1_CK_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 = 0xc02b
 )
 
 // ssl generates a function to upgrade a net.Conn based on the "sslmode" and
@@ -27,6 +29,8 @@ func ssl(o values) (func(net.Conn) (net.Conn, error), error) {
 		TLS1_CK_RSA_WITH_AES_128_SHA256,
 		TLS1_CK_ECDHE_ECDSA_WITH_AES_128_SHA256,
 		TLS1_CK_ECDHE_RSA_WITH_AES_128_SHA256,
+                TLS1_CK_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+                TLS1_CK_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 	}
 	switch mode := o["sslmode"]; mode {
 	// "require" is the default.

--- a/ssl.go
+++ b/ssl.go
@@ -11,12 +11,14 @@ import (
 )
 
 const (
-	TLS1_CK_RSA_WITH_AES_128_GCM_SHA256     = 0x09C
-	TLS1_CK_RSA_WITH_AES_128_SHA256         = 0x03c
-	TLS1_CK_ECDHE_ECDSA_WITH_AES_128_SHA256 = 0xc023
-	TLS1_CK_ECDHE_RSA_WITH_AES_128_SHA256   = 0xc027
+        TLS1_CK_ECDHE_RSA_WITH_AES_256_GCM_SHA384 = 0xc030
         TLS1_CK_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 = 0xc02c
         TLS1_CK_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 = 0xc02b
+        TLS1_CK_RSA_WITH_AES_128_GCM_SHA256 = 0x009c
+        TLS1_CK_RSA_WITH_AES_256_GCM_SHA384 = 0x009d
+        TLS1_CK_RSA_WITH_AES_128_SHA256 = 0x03c
+        TLS1_CK_ECDHE_ECDSA_WITH_AES_128_SHA256 = 0xc023
+        TLS1_CK_ECDHE_RSA_WITH_AES_128_SHA256   = 0xc027
 )
 
 // ssl generates a function to upgrade a net.Conn based on the "sslmode" and
@@ -24,14 +26,17 @@ const (
 func ssl(o values) (func(net.Conn) (net.Conn, error), error) {
 	verifyCaOnly := false
 	tlsConf := tls.Config{}
+        tlsConf.MinVersion = tls.VersionTLS12
 	tlsConf.CipherSuites = []uint16{
-		TLS1_CK_RSA_WITH_AES_128_GCM_SHA256,
-		TLS1_CK_RSA_WITH_AES_128_SHA256,
-		TLS1_CK_ECDHE_ECDSA_WITH_AES_128_SHA256,
-		TLS1_CK_ECDHE_RSA_WITH_AES_128_SHA256,
+                TLS1_CK_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
                 TLS1_CK_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
                 TLS1_CK_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-	}
+                TLS1_CK_RSA_WITH_AES_128_GCM_SHA256,
+                TLS1_CK_RSA_WITH_AES_256_GCM_SHA384,
+                TLS1_CK_RSA_WITH_AES_128_SHA256,
+                TLS1_CK_ECDHE_ECDSA_WITH_AES_128_SHA256,
+                TLS1_CK_ECDHE_RSA_WITH_AES_128_SHA256,
+        }
 	switch mode := o["sslmode"]; mode {
 	// "require" is the default.
 	case "", "require":


### PR DESCRIPTION
**Description:** 
This PR address two issues:
1) The "nzgo" driver was encountering a "remote error: tls: handshake failure" when attempting to connect to the Netezza database using ciphers "ECDHE_ECDSA_WITH_AES_256_GCM_SHA384" and "ECDHE_ECDSA_WITH_AES_128_GCM_SHA256". 
2) The "nzgo" driver is fetching "AES128-GCM-SHA256" cipher instead of "ECDHE-RSA-AES256-GCM-SHA384" cipher while running Linux driver test.

**Solution:** 
To resolve the issues, I have added support for the latest ciphers in ssl.go. Also, I have improved security within the driver by setting the minimum TLS version to 1.2. 

**Testing:** 
I have tested the changes with different connection scenarios, including connections to the Netezza database using  new ciphers. All tests have passed successfully, and I have also verified the continued compatibility with other 
existing cipher suites.