### PR TITLE
Fixing oid imports to avoid using nzgo v11

### DIFF
--- a/buf.go
+++ b/buf.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 
-	"github.com/IBM/nzgo/oid"
+	"github.com/IBM/nzgo/v12/oid"
 )
 
 type readBuf []byte

--- a/conn.go
+++ b/conn.go
@@ -25,7 +25,7 @@ import (
 	"unicode"
 	"unsafe"
 
-	"github.com/IBM/nzgo/oid"
+	"github.com/IBM/nzgo/v12/oid"
 )
 
 // Common error types

--- a/encode.go
+++ b/encode.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/IBM/nzgo/oid"
+	"github.com/IBM/nzgo/v12/oid"
 )
 
 func binaryEncode(parameterStatus *parameterStatus, x interface{}) []byte {

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,6 @@
 module github.com/IBM/nzgo/v12
 
 go 1.15
-require(
-        github.com/IBM/nzgo v11.1.0+incompatible
-)
 
 // Do not use these versions
 retract (

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/IBM/nzgo v11.1.0+incompatible h1:CaaDdlBodPo+ZiHuMMWBpfSQlSH88/nxCzsdCnQRbAA=
-github.com/IBM/nzgo v11.1.0+incompatible/go.mod h1:n1QK6KJjNa8fe+HQPynW+mJpRpkffLXMO8LR9Nja0JU=

--- a/rows.go
+++ b/rows.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/IBM/nzgo/oid"
+	"github.com/IBM/nzgo/v12/oid"
 )
 
 const headerSize = 16


### PR DESCRIPTION
This is a fix for https://github.com/IBM/nzgo/issues/61.
The goal here is to do the right way of import of nzgo/oid package from this module (which is nzgo/v12 not nzgo). After doing do, requirements for `github.com/IBM/nzgo v11.1.0+incompatible` is not needed any more.

To verify the code, I run tests (`go test -vet=off -run .`) and got `PASS` result.