### PR TITLE
avoid hashing the password when password is jwt token.

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -3226,7 +3226,7 @@ func isJWT(token string) bool {
 
 	//Decode the header
 	header, err := b64.RawURLEncoding.DecodeString(parts[0])
-	if err!= nil {
+	if err != nil {
 		return false
 	}
 

--- a/conn.go
+++ b/conn.go
@@ -3294,8 +3294,9 @@ func (cn *conn) Conn_authenticate(o values) (status bool, err error) {
 		elog.Debugf(chopPath(funName()), "Salt value  %s\n", saltStr)
 		w := cn.writeBuf('p')
 		var sFinal string
+		const MinJWTTokenLen = 128 //Minimum length of the JWT token
 
-		if isJWT(o["password"]) {
+		if len(o["password"]) > MinJWTTokenLen && isJWT(o["password"]) {
 			sFinal = o["password"]
 			elog.Debugln(chopPath(funName()), "Password is a JWT token")
 		} else {

--- a/conn.go
+++ b/conn.go
@@ -24,6 +24,7 @@ import (
 	"time"
 	"unicode"
 	"unsafe"
+	"encoding/json"
 
 	"github.com/IBM/nzgo/v12/oid"
 )

--- a/conn.go
+++ b/conn.go
@@ -24,7 +24,7 @@ import (
 	"time"
 	"unicode"
 	"unsafe"
-	"encoding/json"
+	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/IBM/nzgo/v12/oid"
 )
@@ -3218,26 +3218,11 @@ func (cn *conn) Conn_processAuthResponse() (status bool, err error) {
 }
 
 func isJWT(token string) bool {
-
-	//Check if the string is in JWT token pattern
-	parts := strings.Split(token, ".")
-	if len(parts) != 3 {
-		return false
-	}
-
-	//Decode the header
-	header, err := b64.RawURLEncoding.DecodeString(parts[0])
-	if err != nil {
-		return false
-	}
-
-	// Try to unmarshal header into JSON to check if it's valid
-	var headerJson map[string]interface{}
-	if err := json.Unmarshal(header, &headerJson); err != nil {
-		return false
-	}
-
-	return true
+    _, _, err := new(jwt.Parser).ParseUnverified(token, jwt.MapClaims{})
+    if err != nil {
+        return false
+    }
+    return true
 }
 
 func (cn *conn) Conn_authenticate(o values) (status bool, err error) {

--- a/conn.go
+++ b/conn.go
@@ -3217,10 +3217,25 @@ func (cn *conn) Conn_processAuthResponse() (status bool, err error) {
 }
 
 func isJWT(token string) bool {
+
+	//Check if the string is in JWT token pattern
 	parts := strings.Split(token, ".")
 	if len(parts) != 3 {
 		return false
 	}
+
+	//Decode the header
+	header, err := b64.RawURLEncoding.DecodeString(parts[0])
+	if err!= nil {
+		return false
+	}
+
+	// Try to unmarshal header into JSON to check if it's valid
+	var headerJson map[string]interface{}
+	if err := json.Unmarshal(header, &headerJson); err != nil {
+		return false
+	}
+
 	return true
 }
 


### PR DESCRIPTION
JIRA Story (/Task) link: [NEXTGEN-159341](https://jsw.ibm.com/browse/NEXTGEN-159341)

Problem: When we set the hostssl connection to encryption in cloud systems, connect with password as token failed to authenticate user even though the password is correct.
The problem is with SHA256 algorithm limitation. It is not able to handle JWT token encryption/decryption.

Solution:
Skip if the password is token and encrypt the passwords.

testing:
[nzgo testing.txt](https://github.com/user-attachments/files/16945830/nzgo.testing.txt)

web-console testing with sha256 enabled on NPS:

https://github.com/user-attachments/assets/3fe4ec94-a24b-4008-ac40-46ebc5971874


