### PR TITLE
Allow build for AIX

### DIFF
--- a/user_posix.go
+++ b/user_posix.go
@@ -1,6 +1,6 @@
 // Package nzgo is a pure Go Postgres driver for the database/sql package.
 
-// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris rumprun
+// +build aix darwin dragonfly freebsd linux nacl netbsd openbsd solaris rumprun
 
 package nzgo
 


### PR DESCRIPTION
This PR adds aix to the build tags to enable building for aix/ppc64.

Issue: IBM/nzgo#64