### PR TITLE
[NEXTGEN-13161] : Go Driver : Connection failed for onlySecured and PrefferedSecured when SSL mode is disable.

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -11,7 +11,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"github.com/golang-jwt/jwt/v5"
 	"io"
 	"math"
 	"net"
@@ -25,6 +24,8 @@ import (
 	"time"
 	"unicode"
 	"unsafe"
+
+	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/IBM/nzgo/v12/oid"
 )
@@ -265,7 +266,7 @@ const (
 	PG_PROTOCOL_5
 )
 
-//Client Type
+// Client Type
 const (
 	NPSCLIENT_TYPE_GOLANG = 12
 )
@@ -3362,7 +3363,8 @@ func (cn *conn) Conn_send_database(o values) (bool, error) {
 	return false, nil
 }
 
-/*Cases which will fail:
+/*
+Cases which will fail:
 Client-> Preferred secured; Server-> Only Unsecured
 Client-> Preferred Unsecured; Server-> Only Secured
 All other cases of client and server combination will be taken care of.
@@ -3434,7 +3436,10 @@ func (cn *conn) Conn_secure_session() (bool, error) {
 				 *   only secured sessions.
 				 */
 				upgrade, err = ssl(cn.opts)
-				if err == nil {
+				if upgrade == nil && err == nil {
+					elog.Infoln(chopPath(funName()), "Host expecting ssl connection but sslmode set to disable")
+					return false, elog.Fatalf(chopPath(funName()), "ERROR_CONN_FAIL")
+				} else if err == nil {
 					information = HSV2_SSL_CONNECT
 
 				} else {
@@ -4064,10 +4069,10 @@ func (rs *rows) NextResultSet() error {
 // QuoteIdentifier quotes an "identifier" (e.g. a table or a column name) to be
 // used as part of an SQL statement.  For example:
 //
-//    tblname := "my_table"
-//    data := "my_data"
-//    quoted := pq.QuoteIdentifier(tblname)
-//    err := db.Exec(fmt.Sprintf("INSERT INTO %s VALUES ($1)", quoted), data)
+//	tblname := "my_table"
+//	data := "my_data"
+//	quoted := pq.QuoteIdentifier(tblname)
+//	err := db.Exec(fmt.Sprintf("INSERT INTO %s VALUES ($1)", quoted), data)
 //
 // Any double quotes in name will be escaped.  The quoted identifier will be
 // case sensitive when used in a query.  If the input string contains a zero

--- a/conn.go
+++ b/conn.go
@@ -11,6 +11,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"github.com/golang-jwt/jwt/v5"
 	"io"
 	"math"
 	"net"
@@ -24,8 +25,6 @@ import (
 	"time"
 	"unicode"
 	"unsafe"
-
-	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/IBM/nzgo/v12/oid"
 )
@@ -266,7 +265,7 @@ const (
 	PG_PROTOCOL_5
 )
 
-// Client Type
+//Client Type
 const (
 	NPSCLIENT_TYPE_GOLANG = 12
 )
@@ -3363,8 +3362,7 @@ func (cn *conn) Conn_send_database(o values) (bool, error) {
 	return false, nil
 }
 
-/*
-Cases which will fail:
+/*Cases which will fail:
 Client-> Preferred secured; Server-> Only Unsecured
 Client-> Preferred Unsecured; Server-> Only Secured
 All other cases of client and server combination will be taken care of.
@@ -3436,10 +3434,7 @@ func (cn *conn) Conn_secure_session() (bool, error) {
 				 *   only secured sessions.
 				 */
 				upgrade, err = ssl(cn.opts)
-				if upgrade == nil && err == nil {
-					elog.Infoln(chopPath(funName()), "Host expecting ssl connection but sslmode set to disable")
-					return false, elog.Fatalf(chopPath(funName()), "ERROR_CONN_FAIL")
-				} else if err == nil {
+				if err == nil {
 					information = HSV2_SSL_CONNECT
 
 				} else {
@@ -4069,10 +4064,10 @@ func (rs *rows) NextResultSet() error {
 // QuoteIdentifier quotes an "identifier" (e.g. a table or a column name) to be
 // used as part of an SQL statement.  For example:
 //
-//	tblname := "my_table"
-//	data := "my_data"
-//	quoted := pq.QuoteIdentifier(tblname)
-//	err := db.Exec(fmt.Sprintf("INSERT INTO %s VALUES ($1)", quoted), data)
+//    tblname := "my_table"
+//    data := "my_data"
+//    quoted := pq.QuoteIdentifier(tblname)
+//    err := db.Exec(fmt.Sprintf("INSERT INTO %s VALUES ($1)", quoted), data)
 //
 // Any double quotes in name will be escaped.  The quoted identifier will be
 // case sensitive when used in a query.  If the input string contains a zero

--- a/conn.go
+++ b/conn.go
@@ -566,10 +566,6 @@ func (c *Connector) open(ctx context.Context) (cn *conn, err error) {
 
 func dial(ctx context.Context, d Dialer, o values) (net.Conn, error) {
 	network, address := network(o)
-	// SSL is not necessary or supported over UNIX domain sockets
-	if network == "unix" {
-		o["sslmode"] = "disable"
-	}
 
 	elog.Debugln("Network ", network)
 	elog.Debugln("Address ", address)
@@ -3438,7 +3434,7 @@ func (cn *conn) Conn_secure_session() (bool, error) {
 					information = HSV2_SSL_CONNECT
 
 				} else {
-					elog.Debugf(chopPath(funName()), err.Error())
+					return false, elog.Fatalf(chopPath(funName()), err.Error())
 					/* We failed to initialize SSL_context*/
 				}
 			case 'N':

--- a/ssl.go
+++ b/ssl.go
@@ -66,10 +66,8 @@ func ssl(o values) (func(net.Conn) (net.Conn, error), error) {
 		verifyCaOnly = true
 	case "verify-full":
 		tlsConf.ServerName = o["host"]
-	case "disable":
-		return nil, nil
 	default:
-		return nil, fmterrorf(`unsupported sslmode %q; only "require" (default), "verify-full", "verify-ca", and "disable" supported`, mode)
+		return nil, fmterrorf(`unsupported sslmode %q; only "require" (default), "verify-full", and "verify-ca" supported`, mode)
 	}
 
 	err := sslClientCertificates(&tlsConf, o)


### PR DESCRIPTION
**Problem**: When host is expecting ssl connection but sslmode is set to disable, ssl returns null causing segmentation fault.

```
Hostssl                                        sslmode

0 : Preferred UnSecured session		   |	disable	|	crash(SEGV)
2 : Preferred Secured session		   |	disable |	crash(SEGV)
3 : Only Secured session	           |    disable	|	Crash(SEGV)

Host

2 : Preferred Secured session		   |	disable |	Crash(SEGV)
3 : Only Secured session	           |	disable	|	Crash(SEGV)
```

**Solution**: Analyzing the code, it would seem that sslmode disable option does not play a significant role in the current implementation. For unsecured connection, sslmode are not considered and for all the cases of secured connection we are getting segv where we pass sslmode disable. hence, removed the disable option as it wont have any impact on the established behavior of the product.

[nzgo_testing1.txt](https://github.com/user-attachments/files/18842761/nzgo_testing1.txt)


